### PR TITLE
Abort on startup when running on unsupported versions of Redis

### DIFF
--- a/lib/batsd/redis.rb
+++ b/lib/batsd/redis.rb
@@ -12,6 +12,9 @@ module Batsd
     def initialize(options)
       @redis = ::Redis.new(options[:redis] || {host: "127.0.0.1", port: 6379} )
       @redis.ping
+      if @redis.info['redis_version'].to_f < 2.5
+        abort "You need Redis 2.6+ in order to run Batsd. See http://redis.io/ for details."
+      end
       @retentions = options[:retentions].keys
     end
     


### PR DESCRIPTION
Checks the version of Redis is >= 2.5 (2.6-RC) by running the `info` command when connection to Redis.

Should help avoid issues such as [#2](https://github.com/noahhl/batsd/issues/2).
