### PR TITLE
Symbolize option keys sent to ::Redis.new

### DIFF
--- a/lib/batsd.rb
+++ b/lib/batsd.rb
@@ -3,6 +3,7 @@ require 'eventmachine'
 require 'redis'
 
 require 'core-ext/array'
+require 'core-ext/hash'
 
 require 'batsd/diskstore'
 require 'batsd/redis'

--- a/lib/batsd/redis.rb
+++ b/lib/batsd/redis.rb
@@ -10,7 +10,7 @@ module Batsd
     # in the configuration or localhost:6379
     #
     def initialize(options)
-      @redis = ::Redis.new(options[:redis] || {host: "127.0.0.1", port: 6379} )
+      @redis = ::Redis.new((options[:redis] || {host: "127.0.0.1", port: 6379}).symbolize_keys)
       @redis.ping
       @lua_support = @redis.info['redis_version'].to_f >= 2.5
       @retentions = options[:retentions].keys

--- a/lib/core-ext/hash.rb
+++ b/lib/core-ext/hash.rb
@@ -1,0 +1,10 @@
+unless {}.respond_to?(:symbolize_keys)
+  class Hash
+    def symbolize_keys
+      inject({}) do |options, (key, value)|
+        options[(key.to_sym rescue key) || key] = value
+      options
+      end
+    end
+  end
+end


### PR DESCRIPTION
I think this will save some people the trouble of forgetting to
symbolize the keys to redis in the config.yml.  Copied the method
from activesupport rather than adding the dependency.

Also, tried to unit test it but it was too sticky and I didn't
want to be presumptuous about pulling in a mock redis library.
That's probably worth its own issue.
