### PR TITLE
Delete metrics by key (fixes #18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.rvmrc
 
 # YARD artifacts
 .yardoc

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Run the server to expose data to clients
 The server is run as a separate process to allow for controlled upgrades of one
 or the other component, without affecting data acquisition or presentation.
 
-Delete an existing data point (e.g. replace <statistic> with "counters:mymetric")
+Delete an existing data point (replace &lt;statistic&gt; with the name of the metric, e.g. "counters:mymetric")
 
     batsd -c config.yml delete <statistic>
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Run the server to expose data to clients
 The server is run as a separate process to allow for controlled upgrades of one
 or the other component, without affecting data acquisition or presentation.
 
+Delete an existing data point (e.g. replace <statistic> with "counters:mymetric")
+
+    batsd -c config.yml delete <statistic>
+
 A sample client to extract data is included in `examples/client.rb`.
 [jeremy/statsd](https://github.com/jeremy/statsd-ruby.git) is the recommended
 ruby statsd client for sending data.

--- a/bin/batsd
+++ b/bin/batsd
@@ -70,11 +70,10 @@ begin
                }
     Batsd::Receiver::Daemon.new(handlers, config).run
   when :delete
-    statistic = ARGV[1]
-    if !statistic.nil? && !statistic.empty?
+    if ARGV[1] && !ARGV[1].empty?
       @deleter = Batsd::Deleter.new(config)
-      @deleter.delete(statistic)
-      puts "Deleted \"#{statistic}\"."
+      @deleter.delete(ARGV[1])
+      puts "Deleted \"#{ARGV[1]}\"."
     else
       puts "Need to specify a statistic."
       exit 1

--- a/bin/batsd
+++ b/bin/batsd
@@ -69,6 +69,16 @@ begin
                  ms: Batsd::Handler::Timer.new(config)
                }
     Batsd::Receiver::Daemon.new(handlers, config).run
+  when :delete
+    statistic = ARGV[1]
+    if !statistic.nil? && !statistic.empty?
+      @deleter = Batsd::Deleter.new(config)
+      @deleter.delete(statistic)
+      puts "Deleted \"#{statistic}\"."
+    else
+      puts "Need to specify a statistic."
+      exit 1
+    end
   else
     puts "I don't know how to #{command}."
     exit 1

--- a/lib/batsd.rb
+++ b/lib/batsd.rb
@@ -12,6 +12,7 @@ require 'batsd/server'
 require 'batsd/statistics'
 
 require 'batsd/truncator'
+require 'batsd/deleter'
 require 'batsd/handler'
 require 'batsd/handlers/gauge'
 require 'batsd/handlers/counter'

--- a/lib/batsd/deleter.rb
+++ b/lib/batsd/deleter.rb
@@ -1,10 +1,10 @@
 module Batsd
   #
-  # Handle truncation for redis zsets and files written to disk
+  # Handle deletion for redis zsets and files written to disk
   #
   class Deleter
 
-    # Create a new truncator
+    # Create a new deleter
     #
     # * Establish the diskstore that will be used
     # * Establish the redis connection that will be needed

--- a/lib/batsd/deleter.rb
+++ b/lib/batsd/deleter.rb
@@ -1,0 +1,34 @@
+module Batsd
+  #
+  # Handle truncation for redis zsets and files written to disk
+  #
+  class Deleter
+
+    # Create a new truncator
+    #
+    # * Establish the diskstore that will be used
+    # * Establish the redis connection that will be needed
+    #
+    def initialize(options={})
+      @options = options
+      @redis = Batsd::Redis.new(options )
+      @diskstore = Batsd::Diskstore.new(options[:root])
+    end
+
+    def delete(statistic)
+      retentions = @options[:retentions].keys
+
+      # first retention
+      retentions.shift
+      @redis.clear_key(statistic)
+      @redis.remove_datapoint(statistic)
+
+      # other retentions
+      retentions.each do |retention|
+        key = "#{statistic}:#{retention}"
+        @diskstore.delete(@diskstore.build_filename(key), :delete_empty_dirs => true)
+      end
+    end
+
+  end
+end

--- a/lib/batsd/diskstore.rb
+++ b/lib/batsd/diskstore.rb
@@ -96,5 +96,29 @@ module Batsd
       FileUtils.rm("#{filename}tmp") rescue nil
     end
 
+    # Deletes a file, if it exists.
+    # If :delete_empty_dirs is true, empty directories will be deleted too.
+    #
+    def delete(filename, options={})
+      if File.exists? filename
+        FileUtils.rm(filename)
+      end
+
+      if options[:delete_empty_dirs]
+        p = filename
+        begin
+          2.times do
+            p = File.dirname(p)
+            Dir.rmdir(p) rescue break # only delete if dir is empty, else break
+          end
+        rescue => e
+          puts "Encountered an error trying to remove empty directory #{p}: #{e.class}"
+        end
+      end
+    rescue Errno::ENOENT => e
+      puts "Encountered an ENOENT error trying to delete #{filename}: #{e}" if ENV["VVERBOSE"] 
+    rescue Exception => e
+      puts "Encountered an error trying to delete #{filename}: #{e.class}"
+    end
   end
 end

--- a/lib/batsd/redis.rb
+++ b/lib/batsd/redis.rb
@@ -81,6 +81,11 @@ module Batsd
         end.first
       end
     end
+
+    # Deletes the given key
+    def clear_key(key)
+      @redis.del(key)
+    end
     
     # Create an array out of a string of values delimited by <X>
     def extract_values_from_string(key)
@@ -135,6 +140,13 @@ module Batsd
     #
     def add_datapoint(key)
       @redis.sadd "datapoints", key
+    end
+
+    # Stores a reference to the datapoint in 
+    # the 'datapoints' set
+    #
+    def remove_datapoint(key)
+      @redis.srem "datapoints", key
     end
 
   end

--- a/test/unit/diskstore_test.rb
+++ b/test/unit/diskstore_test.rb
@@ -45,5 +45,17 @@ class DiskstoreTest < Test::Unit::TestCase
     assert_equal 26, @diskstore.read(@statistic, now.to_s, (now + 50).to_s).length
   end
 
+  def test_delete_unlinks_file
+    @diskstore.delete(@diskstore.build_filename(@statistic))
+    assert_equal false, File.exists?(@diskstore.build_filename(@statistic))
+    # parent directory still exists
+    assert_equal true, File.exists?(File.dirname(@diskstore.build_filename(@statistic)))
+    # delete empty parents
+    @diskstore.delete(@diskstore.build_filename(@statistic), :delete_empty_dirs => true)
+    # now both parent directories are gone too
+    assert_equal false, File.exists?(File.dirname(@diskstore.build_filename(@statistic)))
+    assert_equal false, File.exists?(File.dirname(File.dirname(@diskstore.build_filename(@statistic))))
+  end
+
 
 end


### PR DESCRIPTION
This pull request adds `bin/batsd delete <statistic>` to the command line interface.

When invoked it deletes the corresponding key and data point in redis and deletes all files of all retention levels associated with the given metric name. If this leaves any empty directories behind these will be deleted too.

The pull request also includes a test for the disk store deletion.

I appreciate your feedback!
