### PR TITLE
calculated count to always return the count, even if it is 1

### DIFF
--- a/lib/batsd/handlers/timer.rb
+++ b/lib/batsd/handlers/timer.rb
@@ -75,12 +75,12 @@ module Batsd
                 # Store all the aggregates for the flush interval level
                 count = values.count
 
-                combined_values = [count] + @operations.collect do |aggregation|
+                combined_values = @operations.collect do |aggregation|
                   count > 1 ? values.send(aggregation.to_sym) : values.first
                 end
 
                 if count > 0 
-                  combined_values = combined_values.join("/")
+                  combined_values = ([count] + combined_values).join("/")
                   redis.store_timer timestamp, key, combined_values
                 end
 


### PR DESCRIPTION
Ran into this issue on our batsd implementation; arrays with a single value were returning that value as the count, rather than '1'. This was causing secondary calculations we were doing to have errors.

Any feedback would be appreciated!
