### PR TITLE
Consistently return numeric values from server.

### DIFF
--- a/lib/batsd/diskstore.rb
+++ b/lib/batsd/diskstore.rb
@@ -55,7 +55,7 @@ module Batsd
           while (line = file.gets)
             ts, value = line.split
             if ts >= start_ts && ts <= end_ts
-              datapoints << {timestamp: ts.to_i, value: value}
+              datapoints << {timestamp: ts.to_i, value: value.to_f}
             end
           end
           file.close

--- a/lib/batsd/redis.rb
+++ b/lib/batsd/redis.rb
@@ -119,7 +119,7 @@ module Batsd
     def values_from_zset(metric, begin_ts, end_ts)
       begin
         values = @redis.zrangebyscore(metric, begin_ts, end_ts)
-        values.collect{|val| ts, val = val.split("<X>"); {timestamp: ts, value: val } }
+        values.collect{|val| ts, val = val.split("<X>"); {timestamp: ts.to_i, value: val.to_f } }
       rescue
         []
       end


### PR DESCRIPTION
At the moment the server sometimes returns the timestamp as a string, and sometimes as a number, depending on whether the values have been read from Redis or the disk store. This change means that the timestamp will always be returned as a number. Additionally, the value will be returned as a float (instead of a string).
